### PR TITLE
feat: detect node-red directory automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,25 +30,6 @@ Before you can use the plugin you need to full-fill the following requirements o
     node-red restart
     ```
 
-3. After the Node-RED installation, you need to provide some information about the node-red installation to help the plugin know where to find it.
-
-    Create the following folder:
-
-    ```sh
-    sudo mkdir /etc/tedge-nodered
-    ```
-
-    Then add the following contents to the `/etc/tedge-nodered` file. Replace `myuser` with the appropriate user where Node-RED was installed under.
-
-    **File: /etc/tedge-nodered/env**
-
-    ```sh
-    NODERED_USER="myuser"
-    NODERED_HOME="/home/myuser"
-    NODERED_DIR="/home/myuser/.node-red"
-    ACTIVE_PROJECT_FILE="/home/myuser/.node-red/.active_project"
-    ```
-
 ## Plugin summary
 
 Install/remove node-red projects on a device using thin-edge.io software management plugin.

--- a/src/sm-plugin/nodered
+++ b/src/sm-plugin/nodered
@@ -76,11 +76,11 @@ fi
 # Fail if .node-red folder could not be found
 if [ -z "$NODERED_DIR" ]; then
     log "Could not detect Node-RED directory. Please set the NODERED_DIR variable in $SETTINGS_FILE and try again"
-    exit 1
+    exit "$EXIT_USAGE"
 fi
 if [ ! -d "$NODERED_DIR" ]; then
     log "Node-RED directory (NODERED_DIR) does not exist. path=$NODERED_DIR":
-    exit 1
+    exit "$EXIT_USAGE"
 fi
 
 log "Using node-red settings: path=$NODERED_DIR, user=$NODERED_USER"

--- a/src/sm-plugin/nodered
+++ b/src/sm-plugin/nodered
@@ -37,12 +37,10 @@ FILE=
 
 # settings
 PLUGIN_NAME=nodered
-NODERED_USER="iotadmin"
-NODERED_HOME="/home/iotadmin"
-NODERED_DIR="${NODERED_HOME}/.node-red"
+NODERED_USER=""
+NODERED_DIR=""
 PROP_ACTIVE_PROJECT="active-project"
 NODERED_API="http://localhost:1880"
-ACTIVE_PROJECT_FILE="$NODERED_DIR/.active_project"
 
 
 # Only read the file if it has the correct permissions, to prevent people from editing it
@@ -58,6 +56,37 @@ if [ -n "$FOUND_FILE" ]; then
     # shellcheck disable=SC1091,SC1090
     . "$SETTINGS_FILE"
 fi
+
+# Try to detect .node-red folder
+if [ -z "$NODERED_DIR" ]; then
+    if [ -d /home ]; then
+        for userhome in /home/*; do
+            if [ -d "$userhome/.node-red" ]; then
+                NODERED_DIR="$userhome/.node-red"
+                NODERED_USER=$(basename "$userhome")
+                break
+            fi
+        done
+    elif [ -d /root/.node-red ]; then
+        NODERED_DIR=/root/.node-red
+        NODERED_USER=root
+    fi
+fi
+
+# Fail if .node-red folder could not be found
+if [ -z "$NODERED_DIR" ]; then
+    log "Could not detect Node-RED directory. Please set the NODERED_DIR variable in $SETTINGS_FILE and try again"
+    exit 1
+fi
+if [ ! -d "$NODERED_DIR" ]; then
+    log "Node-RED directory (NODERED_DIR) does not exist. path=$NODERED_DIR":
+    exit 1
+fi
+
+log "Using node-red settings: path=$NODERED_DIR, user=$NODERED_USER"
+
+# Set derived settings after loading any settings file
+ACTIVE_PROJECT_FILE="$NODERED_DIR/.active_project"
 
 check_project_mode() {
     PROJECTS=$(curl "$NODERED_API/projects" --silent)


### PR DESCRIPTION
If the NODERED_DIR variable is not set, then detect the .node-red folder automatically by looking under the following paths:

* /home/*/.node-red
* /root/.node-red

The user can still set the directory path in the `/etc/tedge-nodered/env` file to control it manually if a non-default directory is used.