### PR TITLE
feat: enable nodered project automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,33 +2,7 @@
 
 ## Pre-requisites
 
-Before you can use the plugin you need to full-fill the following requirements on your device.
-
-1. You need to have node-red already installed on your device. If you don't already have it then check out the [Node-RED documentation](https://nodered.org/docs/getting-started/)
-
-2. Enable Node-RED projects by editing the `settings.js` file.
-
-    The `editorTheme.projects` settings needs to be changed to `true`. Below shows an example after the setting has been made.
-
-    ```js
-    {
-        module.exports = {
-            // ... other settings
-            editorTheme: {
-                // ... other settings
-                projects: true,
-                workflow: {
-                    mode: "manual"
-                }
-            }
-        }
-    }
-
-    You will need to restart Node-RED for the setting to take effect.
-
-    ```sh
-    node-red restart
-    ```
+You need to have node-red already installed on your device. If you don't already have it then check out the [Node-RED documentation](https://nodered.org/docs/getting-started/).
 
 ## Plugin summary
 

--- a/images/files/settings.js
+++ b/images/files/settings.js
@@ -390,7 +390,7 @@ module.exports = {
 
         projects: {
             /** To enable the Projects feature, set this value to true */
-            enabled: true,
+            enabled: false,
             workflow: {
                 /** Set the default projects workflow mode.
                  *  - manual - you must manually commit changes

--- a/src/sm-plugin/nodered
+++ b/src/sm-plugin/nodered
@@ -363,6 +363,20 @@ case "$COMMAND" in
         ;;
 
     prepare)
+        # Enable Node-RED projects feature (required by this plugin)
+        if ! grep -F "NODE_RED_ENABLE_PROJECTS=" "$NODERED_DIR/EnvironmentFile" -q >/dev/null 2>&1; then
+            SUDO=""
+            if is_root; then
+                # Extract using the user node-red user to prevent file reading problems
+                SUDO="sudo -u $NODERED_USER"
+            fi
+            log "Enabling Node-RED projects. Adding NODE_RED_ENABLE_PROJECTS=true to $NODERED_DIR/EnvironmentFile"
+            echo "NODE_RED_ENABLE_PROJECTS=true" | $SUDO tee "$NODERED_DIR/EnvironmentFile" >/dev/null
+
+            # Restart is required after activating project feature
+            restart_node_red
+            sleep 5
+        fi
         ;;
 
     finalize)


### PR DESCRIPTION
Enable the Node-RED projects feature (required by the plugin) automatically when activating a project.