### PR TITLE
fix(uninstall): support removing project by just removing the active-project package

### DIFF
--- a/src/sm-plugin/nodered
+++ b/src/sm-plugin/nodered
@@ -126,7 +126,7 @@ activate_project() {
     if [ "$(echo "$response" | jq -r '.active')" = "$name" ]; then
         log "\nSuccessfully activated project. name=$name"
     else
-        log "\nFailed however sometimes the service needs to be restated before the setting is active. response=$response"
+        log "\nFailed however sometimes the service needs to be restarted before the setting is active. response=$response"
     fi
 
     #
@@ -148,7 +148,7 @@ activate_project() {
         exit "$EXIT_FAILURE"
     fi
 
-    log "node-red project was activate successfully. name=$CURRENT_PROJECT"
+    log "node-red project was activated successfully. name=$CURRENT_PROJECT"
 }
 
 install_project_from_tarball() {
@@ -349,17 +349,37 @@ case "$COMMAND" in
 
     remove)
         # don't fail if it does not exist
+
+        # Support removing the project when the user removes the
+        # active project.
+        # This might be changed to actually just disable the project in node-red
+        # but the API is unclear how to do this. So for now just remove the project.
+        # The user can always just disable the node-red service if they want to disable
+        # the project temporarily
+        if [ "$MODULE_NAME" = "$PROP_ACTIVE_PROJECT" ]; then
+            log "Setting project name from active project property: name=$MODULE_VERSION"
+            MODULE_NAME="$MODULE_VERSION"
+            # we don't know really care about the module version in this case
+            MODULE_VERSION=""
+        fi
+
         log "Removing ${PLUGIN_NAME} package: ${MODULE_NAME}:${MODULE_VERSION}"
 
         PROJECT_DIR="$NODERED_DIR/projects/$MODULE_NAME"
         log "Removing node-red project. path=$PROJECT_DIR"
 
-        if grep -F "$MODULE_NAME" "$ACTIVE_PROJECT_FILE" -q; then
+        requires_restart=0
+        if grep -F "$MODULE_NAME" "$ACTIVE_PROJECT_FILE" -q >/dev/null 2>&1; then
             rm -f "$ACTIVE_PROJECT_FILE"
+            requires_restart=1
         fi
 
-        # TODO: Should the project be official deregistered from nodered before it is removed?
         rm -Rf "$PROJECT_DIR"
+
+        if [ "$requires_restart" = "1" ]; then
+            restart_node_red
+            sleep 5
+        fi
         ;;
 
     prepare)

--- a/src/sm-plugin/nodered
+++ b/src/sm-plugin/nodered
@@ -300,7 +300,6 @@ case "$COMMAND" in
             exit 0
         fi
 
-        check_project_mode
 
         log "Installing ${PLUGIN_NAME} package: ${MODULE_NAME}:${MODULE_VERSION}"
 
@@ -397,6 +396,16 @@ case "$COMMAND" in
             restart_node_red
             sleep 5
         fi
+
+        # Check if the api is reachable as this is an indication if it is running or not
+        if ! curl --silent -H "Content-Type: application/json" -XGET "$NODERED_API/projects" 2>/dev/null; then
+            log "Starting node-red as the endpoint was not reachable"
+            restart_node_red
+            sleep 5
+        fi
+
+        # Verify that the project feature is enabled
+        check_project_mode
         ;;
 
     finalize)

--- a/tests/main/management.robot
+++ b/tests/main/management.robot
@@ -46,3 +46,13 @@ Uninstall node-red project via Cumulocity using the active project
     Should Not Contain    ${mo}    nodered-demo
     Should Not Contain    ${mo}    active-project
     Cumulocity.Should Have Services    name=nodered-temperature-flow    status=down    service_type=nodered
+
+Install new project when nodered is not running
+    ${operation}=    Cumulocity.Execute Shell Command    text=sudo systemctl stop nodered
+    Operation Should Be SUCCESSFUL    ${operation}
+
+    ${binary_url}=    Cumulocity.Create Inventory Binary    nodered-demo    nodered-project    file=${CURDIR}/../testdata/nodered-demo__main@c7c6b5d.tar.gz
+    ${operation}=    Cumulocity.Install Software    nodered-demo,latest::nodered,${binary_url}    active-project,nodered-demo::nodered
+    Operation Should Be SUCCESSFUL    ${operation}
+    Cumulocity.Device Should Have Installed Software    nodered-demo,0.0.1
+    Cumulocity.Should Have Services    name=nodered-temperature-flow    status=up    service_type=nodered

--- a/tests/main/management.robot
+++ b/tests/main/management.robot
@@ -12,13 +12,14 @@ Install node-red from github url
     ${operation}=    Cumulocity.Install Software    nodered-demo,latest::nodered,${binary_url}    active-project,nodered-demo::nodered
     Operation Should Be SUCCESSFUL    ${operation}
     Cumulocity.Device Should Have Installed Software    nodered-demo
+    Cumulocity.Should Have Services    name=nodered-temperature-flow    status=up    service_type=nodered
 
 Install node-red from tarball
     ${binary_url}=    Cumulocity.Create Inventory Binary    nodered-demo    nodered-project    file=${CURDIR}/../testdata/nodered-demo__main@c7c6b5d.tar.gz
     ${operation}=    Cumulocity.Install Software    nodered-demo,latest::nodered,${binary_url}    active-project,nodered-demo::nodered
     Operation Should Be SUCCESSFUL    ${operation}
     Cumulocity.Device Should Have Installed Software    nodered-demo,0.0.1
-
+    Cumulocity.Should Have Services    name=nodered-temperature-flow    status=up    service_type=nodered
 
 Uninstall node-red project via Cumulocity
     # Skip    Missing Uninstall software keyword
@@ -27,3 +28,21 @@ Uninstall node-red project via Cumulocity
     ${mo}=    Cumulocity.Device Should Have Fragments    c8y_SoftwareList
     Log    ${mo}
     Should Not Contain    ${mo}    nodered-demo
+    Cumulocity.Should Have Services    name=nodered-temperature-flow    status=down    service_type=nodered
+
+Uninstall node-red project via Cumulocity using the active project
+    # install first
+    ${binary_url}=    Cumulocity.Create Inventory Binary    nodered-demo    nodered-project    file=${CURDIR}/../testdata/nodered-demo__main@c7c6b5d.tar.gz
+    ${operation}=    Cumulocity.Install Software    nodered-demo,latest::nodered,${binary_url}    active-project,nodered-demo::nodered
+    Operation Should Be SUCCESSFUL    ${operation}
+    Cumulocity.Device Should Have Installed Software    nodered-demo,0.0.1
+    Cumulocity.Should Have Services    name=nodered-temperature-flow    status=up    service_type=nodered
+
+    # then remove
+    ${operation}=    Cumulocity.Create Operation    fragments={"c8y_SoftwareUpdate":[{"name":"active-project","version":"nodered-demo::nodered","url":"","action":"delete"}]}    description=Remove nodered-demo package
+    Operation Should Be SUCCESSFUL    ${operation}
+    ${mo}=    Cumulocity.Device Should Have Fragments    c8y_SoftwareList
+    Log    ${mo}
+    Should Not Contain    ${mo}    nodered-demo
+    Should Not Contain    ${mo}    active-project
+    Cumulocity.Should Have Services    name=nodered-temperature-flow    status=down    service_type=nodered

--- a/tests/main/telemetry.robot
+++ b/tests/main/telemetry.robot
@@ -27,5 +27,5 @@ node-red status should publish to health endpoint
 Custom Setup
     Set Main Device
     ${binary_url}=    Cumulocity.Create Inventory Binary    nodered-demo    nodered-project    file=${CURDIR}/../testdata/nodered-demo.cfg
-    ${operation}=    Cumulocity.Install Software    nodered-demo,latest::nodered,${binary_url}
+    ${operation}=    Cumulocity.Install Software    nodered-demo,latest::nodered,${binary_url}    active-project,nodered-demo::nodered
     Operation Should Be SUCCESSFUL    ${operation}


### PR DESCRIPTION
If an remove software package operation is sent which only contains the `active-project` nodered package, then the active project will also be removed automatically (without having to specify the package explicitly).