### PR TITLE
tests: update libraries and use new software type syntax instead of encoding type in the version

### DIFF
--- a/tests/main/management.robot
+++ b/tests/main/management.robot
@@ -12,36 +12,40 @@ ${PROJECT_TARBALL}    ${CURDIR}/../testdata/nodered-demo__main@a6293b6.tar.gz
 
 Install node-red from github url
     ${binary_url}=    Cumulocity.Create Inventory Binary    nodered-demo    nodered-project    file=${CURDIR}/../testdata/nodered-demo.cfg
-    ${operation}=    Cumulocity.Install Software    nodered-demo,latest::nodered,${binary_url}    active-project,nodered-demo::nodered
+    ${operation}=    Cumulocity.Install Software
+    ...    {"name":"nodered-demo", "version":"latest", "softwareType":"nodered", "url":"${binary_url}"}
+    ...    {"name":"active-project", "version":"nodered-demo", "softwareType":"nodered"}
     Operation Should Be SUCCESSFUL    ${operation}
-    Cumulocity.Device Should Have Installed Software    nodered-demo
+    Cumulocity.Device Should Have Installed Software    {"name": "nodered-demo", "softwareType": "nodered"}
     Cumulocity.Should Have Services    name=nodered-temperature-flow    status=up    service_type=nodered
 
 Install node-red from tarball
     ${binary_url}=    Cumulocity.Create Inventory Binary    nodered-demo    nodered-project    file=${PROJECT_TARBALL}
-    ${operation}=    Cumulocity.Install Software    nodered-demo,latest::nodered,${binary_url}    active-project,nodered-demo::nodered
+    ${operation}=    Cumulocity.Install Software
+    ...    {"name":"nodered-demo", "version":"latest", "softwareType":"nodered", "url":"${binary_url}"}
+    ...    {"name":"active-project", "version":"nodered-demo", "softwareType":"nodered"}
     Operation Should Be SUCCESSFUL    ${operation}
-    Cumulocity.Device Should Have Installed Software    nodered-demo,0.0.1
+    Cumulocity.Device Should Have Installed Software    {"name": "nodered-demo", "version": "0.0.1", "softwareType": "nodered"}
     Cumulocity.Should Have Services    name=nodered-temperature-flow    status=up    service_type=nodered
 
 Uninstall node-red project via Cumulocity
-    ${operation}=    Cumulocity.Create Operation    fragments={"c8y_SoftwareUpdate":[{"name":"nodered-demo","version":"latest::nodered","url":"","action":"delete"}]}    description=Remove nodered-demo package
+    ${operation}=    Cumulocity.Uninstall Software    {"name": "nodered-demo", "version": "latest", "softwareType": "nodered"}
     Operation Should Be SUCCESSFUL    ${operation}
-    ${mo}=    Cumulocity.Device Should Have Fragments    c8y_SoftwareList
-    Log    ${mo}
-    Should Not Contain    ${mo}    nodered-demo
+    Cumulocity.Device Should Not Have Installed Software    {"name": "nodered-demo", "softwareType": "nodered"}
     Cumulocity.Should Have Services    name=nodered-temperature-flow    status=down    service_type=nodered
 
 Uninstall node-red project via Cumulocity using the active project
     # install first
     ${binary_url}=    Cumulocity.Create Inventory Binary    nodered-demo    nodered-project    file=${PROJECT_TARBALL}
-    ${operation}=    Cumulocity.Install Software    nodered-demo,latest::nodered,${binary_url}    active-project,nodered-demo::nodered
+    ${operation}=    Cumulocity.Install Software
+    ...    {"name":"nodered-demo", "version":"latest", "softwareType":"nodered", "url":"${binary_url}"}
+    ...    {"name":"active-project", "version":"nodered-demo", "softwareType":"nodered"}
     Operation Should Be SUCCESSFUL    ${operation}
-    Cumulocity.Device Should Have Installed Software    nodered-demo,0.0.1
+    Cumulocity.Device Should Have Installed Software    {"name": "nodered-demo", "version": "0.0.1", "softwareType": "nodered"}
     Cumulocity.Should Have Services    name=nodered-temperature-flow    status=up    service_type=nodered
 
     # then remove
-    ${operation}=    Cumulocity.Create Operation    fragments={"c8y_SoftwareUpdate":[{"name":"active-project","version":"nodered-demo::nodered","url":"","action":"delete"}]}    description=Remove nodered-demo package
+    ${operation}=    Cumulocity.Uninstall Software    {"name": "active-project", "version": "nodered-demo", "softwareType": "nodered"}
     Operation Should Be SUCCESSFUL    ${operation}
     ${mo}=    Cumulocity.Device Should Have Fragments    c8y_SoftwareList
     Log    ${mo}
@@ -54,22 +58,26 @@ Install new project when nodered is not running
     Operation Should Be SUCCESSFUL    ${operation}
 
     ${binary_url}=    Cumulocity.Create Inventory Binary    nodered-demo    nodered-project    file=${PROJECT_TARBALL}
-    ${operation}=    Cumulocity.Install Software    nodered-demo,latest::nodered,${binary_url}    active-project,nodered-demo::nodered
+    ${operation}=    Cumulocity.Install Software
+    ...    {"name":"nodered-demo", "version":"latest", "softwareType":"nodered", "url":"${binary_url}"}
+    ...    {"name":"active-project", "version":"nodered-demo", "softwareType":"nodered"}
     Operation Should Be SUCCESSFUL    ${operation}
-    Cumulocity.Device Should Have Installed Software    nodered-demo,0.0.1
+    Cumulocity.Device Should Have Installed Software    {"name": "nodered-demo", "version": "0.0.1", "softwareType": "nodered"}
     Cumulocity.Should Have Services    name=nodered-temperature-flow    status=up    service_type=nodered
 
 Install node-red from github url with space in its name
     [Teardown]    Remove nodered project    nodered demo project
     ${binary_url}=    Cumulocity.Create Inventory Binary    nodered-demo    nodered-project    file=${CURDIR}/../testdata/nodered-demo.cfg
-    ${operation}=    Cumulocity.Install Software    nodered demo project,latest::nodered,${binary_url}    active-project,nodered demo project::nodered
+    ${operation}=    Cumulocity.Install Software
+    ...    {"name":"nodered demo project", "version":"latest", "softwareType":"nodered", "url":"${binary_url}"}
+    ...    {"name":"active-project", "version":"nodered demo project", "softwareType":"nodered"}
     Operation Should Be SUCCESSFUL    ${operation}
-    Cumulocity.Device Should Have Installed Software    nodered demo project
+    Cumulocity.Device Should Have Installed Software    {"name": "nodered demo project", "softwareType": "nodered"}
     Cumulocity.Should Have Services    name=nodered-temperature-flow    status=up    service_type=nodered
 
 *** Keywords ***
 
 Remove nodered project
     [Arguments]    ${name}
-    ${operation}=    Cumulocity.Create Operation    fragments={"c8y_SoftwareUpdate":[{"name":"${name}","version":"latest::nodered","url":"","action":"delete"}]}    description=Remove 'nodered demo project' package
+    ${operation}=    Cumulocity.Uninstall Software    {"name": "${name}", "version": "latest", "softwareType": "nodered"}
     Operation Should Be SUCCESSFUL    ${operation}

--- a/tests/main/telemetry.robot
+++ b/tests/main/telemetry.robot
@@ -27,5 +27,7 @@ node-red status should publish to health endpoint
 Custom Setup
     Set Main Device
     ${binary_url}=    Cumulocity.Create Inventory Binary    nodered-demo    nodered-project    file=${CURDIR}/../testdata/nodered-demo.cfg
-    ${operation}=    Cumulocity.Install Software    nodered-demo,latest::nodered,${binary_url}    active-project,nodered-demo::nodered
+    ${operation}=    Cumulocity.Install Software
+    ...    {"name":"nodered-demo", "version":"latest", "softwareType":"nodered", "url":"${binary_url}"}
+    ...    {"name":"active-project", "version":"nodered-demo", "softwareType":"nodered"}
     Operation Should Be SUCCESSFUL    ${operation}

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 robotframework~=6.0.0
-robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.16.0
-robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.3.0
+robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.31.3
+robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.13.0


### PR DESCRIPTION
Update the test libraries so the new syntax can be used to create and check software by using the proper "softwareType" property as thin-edge.io supports this syntax since 1.0.0