### PR TITLE
ci: switch action to install just to avoid nodejs 16 deprecation warnings

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,10 +49,7 @@ jobs:
           cache-dependency-path: |
             tests/requirements.txt
 
-      - uses: extractions/setup-just@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
+      - uses: taiki-e/install-action@just
       - name: Install dependencies
         run: |
           just venv


### PR DESCRIPTION
Use a different Github action to avoid node16 deprecation warnings when running the test workflow