### PR TITLE
docs: remove old sm-plugin software type syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,17 +153,17 @@ tar cvzf "$ARCHIVE" .
     Then add the version
 
     ```sh
-    c8y software versions create --software nodered-demo --version "$VERSION::nodered" --file ./nodered-demo__master@32256bb.tar.gz
+    c8y software versions create --software nodered-demo --version "$VERSION" --file ./nodered-demo__master@32256bb.tar.gz
 
     # Or using wildcards
-    c8y software versions create --software nodered-demo --version "$VERSION::nodered" --file ./nodered-demo__*@*.tar.gz
+    c8y software versions create --software nodered-demo --version "$VERSION" --file ./nodered-demo__*@*.tar.gz
     ```
 
 3. Create an active flow software entry to control which item should be active. There should be one per flow
 
     ```sh
     c8y software create --name active-flow --description "Active node-red flow" --data softwareType=nodered
-    c8y software versions create --software active-flow --version "nodered-demo::nodered" --url " "
+    c8y software versions create --software active-flow --version "nodered-demo" --url " "
     ```
 
 ### Uploading a project using an external URL
@@ -177,7 +177,7 @@ tar cvzf "$ARCHIVE" .
 2. Create a software version item in Cumulocity IoT
 
     ```sh
-    c8y software versions create --software nodered-demo --version "latest::nodered" --file ./tests/testdata/nodered-demo.cfg
+    c8y software versions create --software nodered-demo --version "latest" --file ./tests/testdata/nodered-demo.cfg
     ```
 
 ## Future ideas

--- a/src/sm-plugin/nodered
+++ b/src/sm-plugin/nodered
@@ -434,14 +434,14 @@ EOF
 
     prepare)
         # Enable Node-RED projects feature (required by this plugin)
-        if ! grep -F "NODE_RED_ENABLE_PROJECTS=" "$NODERED_DIR/EnvironmentFile" -q >/dev/null 2>&1; then
+        if ! grep -F "NODE_RED_ENABLE_PROJECTS=" "$NODERED_DIR/environment" -q >/dev/null 2>&1; then
             SUDO=""
             if is_root; then
                 # Extract using the user node-red user to prevent file reading problems
                 SUDO="sudo -u $NODERED_USER"
             fi
-            log "Enabling Node-RED projects. Adding NODE_RED_ENABLE_PROJECTS=true to $NODERED_DIR/EnvironmentFile"
-            echo "NODE_RED_ENABLE_PROJECTS=true" | $SUDO tee "$NODERED_DIR/EnvironmentFile" >/dev/null
+            log "Enabling Node-RED projects. Adding NODE_RED_ENABLE_PROJECTS=true to $NODERED_DIR/environment"
+            echo "NODE_RED_ENABLE_PROJECTS=true" | $SUDO tee "$NODERED_DIR/environment" >/dev/null
 
             # Restart is required after activating project feature
             restart_node_red


### PR DESCRIPTION
Remove all usage of the older style version syntax where the version includes the software type information (e.g. `1.0.0::nodered`). Since thin-edge.io 1.0.0, the `::<softwaretype>` suffix is no longer required in the version.