### PR TITLE
chore: address github action warnings

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,8 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '>=1.17.0'
+          go-version: 'stable'
+          cache: false
       - run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
         name: Install dependencies
       - name: Set version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
           SEMVER: ${{ env.RELEASE_VERSION }}
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* Update the release github action to avoid deprecation warning
* Disable golang caching as it is not needed and only generates a warning message