### PR TITLE
test: refactor tests to use image based testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,40 +11,48 @@ on:
     branches: [ main ]
   merge_group:
 jobs:
-  test:
-    name: Test
+  approve:
+    name: Approve
     environment:
       # For security reasons, all pull requests need to be approved first before granting access to secrets
       # So the environment should be set to have a reviewer/s inspect it before approving it
       name: ${{ github.event_name == 'pull_request_target' && 'Test Pull Request' || 'Test Auto'  }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for approval
+        run: echo "Approved"
+
+  test:
+    name: Test
+    needs: [approve]
+    environment:
+      name: Test Auto
+    runs-on: ubuntu-latest
     env:
       COMPOSE_PROJECT_NAME: ci_${{github.run_id}}_${{github.run_attempt || '1'}}
-      DEVICE_ID: ci_${{github.run_id}}_${{github.run_attempt || '1'}}
+      IMAGE: ${{ matrix.job.image }}_ci_${{github.run_id}}_${{github.run_attempt || '1'}}
+      IMAGE_SRC: ${{ matrix.job.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - { image: debian-systemd-native }
     steps:
-      # Checkout either the PR or the branch
-      - name: Checkout PR
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR. Only after the manual approval process
-
       - name: Checkout
         uses: actions/checkout@v4
-        if: ${{ github.event_name != 'pull_request_target' }}
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
 
       - name: create .env file
         run: |
           touch .env
-          echo "DEVICE_ID=$DEVICE_ID" >> .env
           echo 'C8Y_BASEURL="${{ secrets.C8Y_BASEURL }}"' >> .env
           echo 'C8Y_USER="${{ secrets.C8Y_USER }}"' >> .env
           echo 'C8Y_PASSWORD="${{ secrets.C8Y_PASSWORD }}"' >> .env
-          cat .env
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: |
             tests/requirements.txt
@@ -53,11 +61,7 @@ jobs:
       - name: Install dependencies
         run: |
           just venv
-
-      - name: Start demo
-        run: |
-          just up
-          just bootstrap --no-prompt
+          just build-test
 
       - name: Run tests
         run: just test
@@ -66,39 +70,12 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: reports
+          name: reports-${{ matrix.job.image }}
           path: output
 
-      - name: Stop demo
-        if: always()
-        run: just down-all
-
-      - name: Install go-c8y-cli
-        if: always()
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          curl -LSs https://github.com/reubenmiller/go-c8y-cli/releases/download/v2.22.4/c8y_linux_$(dpkg --print-architecture) -o "$HOME/.local/bin/c8y"
-          chmod +x "$HOME/.local/bin/c8y"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Cleanup Devices
-        if: always()
-        run: |
-          just cleanup "$DEVICE_ID"
-
-  generate_report:
-    name: Publish report
-    if: ${{ always() && github.event_name == 'pull_request_target' }}
-    needs: [test]
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Download reports
-      uses: actions/download-artifact@v4
-      with:
-        name: reports
-        path: reports
-    - name: Send report to commit
-      uses: joonvena/robotframework-reporter-action@v2.1
-      with:
-        gh_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Send report to commit
+        if: ${{ always() && github.event_name == 'pull_request_target' }}
+        uses: "joonvena/robotframework-reporter-action@v2.5"
+        with:
+          report_path: output
+          gh_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -61,25 +61,6 @@ The following packages are required to use the plugin:
 
 * Activating a new project for the first time does not seem to work for reasons unknown, however restarting the `nodered` service seems to fix this. The root cause should be investigated as it is probably a sign that an API call is missing or the install sequence is wrong.
 
-## Development
-
-### Start demo
-
-1. Start the demo
-
-    ```sh
-    just up
-    ```
-
-2. Open the exposed container port [http://localhost:1880](http://localhost:1880)
-
-
-### Stop demo
-
-```sh
-just down
-```
-
 ## Design
 
 ### Proposed workflow of a node-red project

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,0 @@
-version: '3'
-services:
-  tedge:
-    build:
-      dockerfile: images/Dockerfile
-    privileged: true
-    ports:
-      - 1880:1880

--- a/justfile
+++ b/justfile
@@ -1,34 +1,29 @@
 set dotenv-load
+set export
 
-# Start the demo
-up *args="":
-    docker compose up -d --build {{args}}
+DEVICE_ID := env_var_or_default("DEVICE_ID", "CI_" + file_name(home_directory()) + "_tedge-nodered-plugin" )
+IMAGE := env_var_or_default("IMAGE", "debian-systemd-native")
+IMAGE_SRC := env_var_or_default("IMAGE_SRC", "debian-systemd-native")
 
-# Stop the demo
-down *args="":
-    docker compose down {{args}}
-
-# Stop the demo and destroy the data
-down-all:
-    docker compose down -v
-
-# Configure and register the device to the cloud
-bootstrap *args="":
-    docker compose exec --env "DEVICE_ID=${DEVICE_ID:-}" --env "C8Y_BASEURL=${C8Y_BASEURL:-}" --env "C8Y_USER=${C8Y_USER:-}" --env "C8Y_PASSWORD=${C8Y_PASSWORD:-}" tedge bootstrap.sh {{args}}
-
-# Start a shell
-shell *args='bash':
-    docker compose exec tedge {{args}}
-
-# Show logs of the main device
-logs *args='':
-    docker compose exec tedge journalctl -f -u "c8y-*" -u "tedge-*" {{args}}
-
+# Initialize a dotenv file for usage with a local debugger
+# WARNING: It will override any previously generated dotenv file
+init-dotenv:
+  @echo "Recreating .env file..."
+  @echo "DEVICE_ID=$DEVICE_ID" > .env
+  @echo "IMAGE=$IMAGE" >> .env
+  @echo "IMAGE_SRC=$IMAGE_SRC" >> .env
+  @echo "C8Y_BASEURL=$C8Y_BASEURL" >> .env
+  @echo "C8Y_USER=$C8Y_USER" >> .env
+  @echo "C8Y_PASSWORD=$C8Y_PASSWORD" >> .env
 
 # Install python virtual environment
 venv:
   [ -d .venv ] || python3 -m venv .venv
   ./.venv/bin/pip3 install -r tests/requirements.txt
+
+# Build test images and test artifacts
+build-test:
+  docker build -t {{IMAGE}} -f ./test-images/{{IMAGE_SRC}}/Dockerfile .
 
 # Run tests
 test *args='':
@@ -36,10 +31,3 @@ test *args='':
 
 release:
     ./ci/build.sh
-
-# Cleanup device and all it's dependencies
-cleanup DEVICE_ID $CI="true":
-    echo "Removing device and child devices (including certificates)"
-    c8y devicemanagement certificates list -n --tenant "$(c8y currenttenant get --select name --output csv)" --filter "name eq {{DEVICE_ID}}" --pageSize 2000 | c8y devicemanagement certificates delete --tenant "$(c8y currenttenant get --select name --output csv)"
-    c8y inventory find -n --owner "device_{{DEVICE_ID}}" -p 100 | c8y inventory delete
-    c8y users delete -n --id "device_{{DEVICE_ID}}" --tenant "$(c8y currenttenant get --select name --output csv)" --silentStatusCodes 404 --silentExit

--- a/test-images/debian-systemd-native/Dockerfile
+++ b/test-images/debian-systemd-native/Dockerfile
@@ -1,10 +1,5 @@
 FROM ghcr.io/thin-edge/tedge-demo-main-systemd:latest
-
 ARG TEST_USER=iotadmin
-RUN useradd -ms /bin/bash "${TEST_USER}" \
-    && echo "${TEST_USER}:${TEST_USER}" | chpasswd \
-    && adduser "${TEST_USER}" sudo \
-    && echo '%sudo ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/all
 
 # Install node-red
 RUN curl -sL https://raw.githubusercontent.com/node-red/linux-installers/master/deb/update-nodejs-and-nodered > /tmp/install-nodered.sh \
@@ -18,7 +13,10 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
         git \
         jq \
-        curl
+        curl \
+    && tedge config unset c8y.proxy.client.host \
+    && tedge config unset mqtt.client.host \
+    && tedge config unset http.client.host
 
 # Add custom sm-plugins
 COPY src/sm-plugin/nodered /etc/tedge/sm-plugins/

--- a/tests/main/management.robot
+++ b/tests/main/management.robot
@@ -1,9 +1,8 @@
 *** Settings ***
 Resource    ../resources/common.robot
-Library    Cumulocity
-Library    DeviceLibrary
 
-Suite Setup    Set Main Device
+Suite Setup    Suite Setup
+Test Teardown    Collect Logs
 
 *** Variables ***
 ${PROJECT_TARBALL}    ${CURDIR}/../testdata/nodered-demo__main@a6293b6.tar.gz
@@ -77,6 +76,11 @@ Install node-red from github url with space in its name
 
 *** Keywords ***
 
+Suite Setup
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    $DEVICE_SN
+    Cumulocity.External Identity Should Exist    ${DEVICE_SN}
+    
 Remove nodered project
     [Arguments]    ${name}
     ${operation}=    Cumulocity.Uninstall Software    {"name": "${name}", "version": "latest", "softwareType": "nodered"}

--- a/tests/main/telemetry.robot
+++ b/tests/main/telemetry.robot
@@ -1,9 +1,8 @@
 *** Settings ***
 Resource    ../resources/common.robot
-Library    Cumulocity
-Library    DeviceLibrary
 
 Suite Setup    Custom Setup
+Test Teardown    Collect Logs
 
 *** Test Cases ***
 
@@ -25,7 +24,10 @@ node-red status should publish to health endpoint
 *** Keywords ***
 
 Custom Setup
-    Set Main Device
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    $DEVICE_SN
+    Cumulocity.External Identity Should Exist    ${DEVICE_SN}
+
     ${binary_url}=    Cumulocity.Create Inventory Binary    nodered-demo    nodered-project    file=${CURDIR}/../testdata/nodered-demo.cfg
     ${operation}=    Cumulocity.Install Software
     ...    {"name":"nodered-demo", "version":"latest", "softwareType":"nodered", "url":"${binary_url}"}

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
-robotframework~=6.0.0
-robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.31.3
-robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.13.0
+robotframework~=7.0.0
+robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.37.2
+robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.15.1
+robotframework-debuglibrary~=2.5.0

--- a/tests/resources/common.robot
+++ b/tests/resources/common.robot
@@ -1,22 +1,24 @@
 *** Settings ***
 Library    Cumulocity
+Library    DeviceLibrary    bootstrap_script=bootstrap.sh
 
 *** Variables ***
-
-${DEVICE_ID}         %{DEVICE_ID=main}
-${CHILD_DEVICE_1}    ${DEVICE_ID}_child01
-${CHILD_DEVICE_2}    ${DEVICE_ID}_child02
 
 # Cumulocity settings
 &{C8Y_CONFIG}        host=%{C8Y_BASEURL= }    username=%{C8Y_USER= }    password=%{C8Y_PASSWORD= }    tenant=%{C8Y_TENANT= }
 
+# Docker adapter settings (to control which image is used in the system tests).
+# The user just needs to set the IMAGE env variable
+&{DOCKER_CONFIG}    image=%{IMAGE=}
+
 *** Keywords ***
 
-Set Main Device
-    Cumulocity.Set Device    ${DEVICE_ID}
+Collect Logs
+    Collect Workflow Logs
+    Collect Systemd Logs
 
-Set Child Device1
-    Cumulocity.Set Device    ${CHILD_DEVICE_1}
+Collect Systemd Logs
+    Execute Command    sudo journalctl -n 10000
 
-Set Child Device2
-    Cumulocity.Set Device    ${CHILD_DEVICE_2}
+Collect Workflow Logs
+    Execute Command    cat /var/log/tedge/agent/*


### PR DESCRIPTION
Switch to using the DeviceLibrary to spawn on-demand container for testing. This will allow running a matrix test setup to test different environments (e.g. native and container environments).

Since this is a change in build workflow requires forcefully merging it (after confirm the tests pass on a dedicated run):
* https://github.com/thin-edge/tedge-nodered-plugin/actions/runs/11764429156