### PR TITLE
test: update image used in tests

### DIFF
--- a/test-images/debian-systemd-container/Dockerfile
+++ b/test-images/debian-systemd-container/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/thin-edge/tedge-demo-main-systemd:20241113.1212
+FROM ghcr.io/thin-edge/tedge-demo-main-systemd:20241115.1635
+
 ARG TARGETPLATFORM
 
 # Install additional dependencies

--- a/test-images/debian-systemd-native/Dockerfile
+++ b/test-images/debian-systemd-native/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/thin-edge/tedge-demo-main-systemd:20241113.1212
+FROM ghcr.io/thin-edge/tedge-demo-main-systemd:20241115.1635
 ARG TEST_USER=iotadmin
 
 # Install node-red


### PR DESCRIPTION
Update image to use the latest tedge-container-plugin-ng version.