### PR TITLE
feat: switch back to original package name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,7 +71,7 @@ archives:
 
 nfpms:
   - 
-    package_name: tedge-nodered-plugin-ng
+    package_name: tedge-nodered-plugin
     license: Apache License 2.0
     maintainer: thin-edge.io <thinedge@thin-edge.io>
     homepage: https://github.com/thin-edge/tedge-nodered-plugin
@@ -84,14 +84,6 @@ nfpms:
       - deb
       - rpm
       - apk
-
-    # FIXME: Remove for official release, as the package can be called "tedge-container-plugin" instead of "tedge-container-plugin-ng"
-    replaces:
-      - tedge-nodered-plugin
-    provides:
-      - tedge-nodered-plugin
-    conflicts:
-      - tedge-nodered-plugin
 
     contents:
       - src: /usr/bin/tedge-nodered-plugin

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tedge-nodered-plugin-ng
+# tedge-nodered-plugin
 
 ## Pre-requisites
 
@@ -37,9 +37,9 @@ The following linux package formats are provided on the releases page and also i
 
 |Operating System|Repository link|
 |--|--|
-|Debian/Raspian (deb)|[![Latest version of 'tedge-nodered-plugin-ng' @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/thinedge/community/deb/tedge-nodered-plugin-ng/latest/a=arm64;d=any-distro%252Fany-version;t=binary/?render=true&show_latest=true)](https://cloudsmith.io/~thinedge/repos/community/packages/detail/deb/tedge-nodered-plugin-ng/latest/a=arm64;d=any-distro%252Fany-version;t=binary/)|
-|Alpine Linux (apk)|[![Latest version of 'tedge-nodered-plugin-ng' @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/thinedge/community/alpine/tedge-nodered-plugin-ng/latest/a=aarch64;d=alpine%252Fany-version/?render=true&show_latest=true)](https://cloudsmith.io/~thinedge/repos/community/packages/detail/alpine/tedge-nodered-plugin-ng/latest/a=aarch64;d=alpine%252Fany-version/)|
-|RHEL/CentOS/Fedora (rpm)|[![Latest version of 'tedge-nodered-plugin-ng' @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/thinedge/community/rpm/tedge-nodered-plugin-ng/latest/a=aarch64;d=any-distro%252Fany-version;t=binary/?render=true&show_latest=true)](https://cloudsmith.io/~thinedge/repos/community/packages/detail/rpm/tedge-nodered-plugin-ng/latest/a=aarch64;d=any-distro%252Fany-version;t=binary/)|
+|Debian/Raspbian (deb)|[![Latest version of 'tedge-nodered-plugin' @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/thinedge/community/deb/tedge-nodered-plugin/latest/a=arm64;d=any-distro%252Fany-version;t=binary/?render=true&show_latest=true)](https://cloudsmith.io/~thinedge/repos/community/packages/detail/deb/tedge-nodered-plugin/latest/a=arm64;d=any-distro%252Fany-version;t=binary/)|
+|Alpine Linux (apk)|[![Latest version of 'tedge-nodered-plugin' @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/thinedge/community/alpine/tedge-nodered-plugin/latest/a=aarch64;d=alpine%252Fany-version/?render=true&show_latest=true)](https://cloudsmith.io/~thinedge/repos/community/packages/detail/alpine/tedge-nodered-plugin/latest/a=aarch64;d=alpine%252Fany-version/)|
+|RHEL/CentOS/Fedora (rpm)|[![Latest version of 'tedge-nodered-plugin' @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/thinedge/community/rpm/tedge-nodered-plugin/latest/a=aarch64;d=any-distro%252Fany-version;t=binary/?render=true&show_latest=true)](https://cloudsmith.io/~thinedge/repos/community/packages/detail/rpm/tedge-nodered-plugin/latest/a=aarch64;d=any-distro%252Fany-version;t=binary/)|
 
 ### What will be deployed to the device?
 


### PR DESCRIPTION
Prepare for replacing the original posix shell based package, tedge-nodered-plugin with the rewritten golang based plugin.